### PR TITLE
Add MySQL based interview API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,10 @@ OPENAI_MODEL=deepseek-chat
 TENCENT_OCR_SECRET_ID=<your-tencent-ocr-secret-id>
 TENCENT_OCR_SECRET_KEY=<your-tencent-ocr-secret-key>
 TENCENT_OCR_REGION=<your-tencent-ocr-region>
+
+# MySQL 数据库配置
+MYSQL_HOST=<mysql-host>
+MYSQL_PORT=<mysql-port>
+MYSQL_USER=<mysql-user>
+MYSQL_PASSWORD=<mysql-password>
+MYSQL_DATABASE=<mysql-database>

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@
 
 - `POST /chat/completions` 兼容 OpenAI 格式，根据模型名称代理 DeepSeek 或 QWEN 进行对话。
 
+### 5. 面试题接口 `/interview`
+
+- `GET /interview/meta` 获取所有来源平台及分类列表。
+- `GET /interview/questions` 按来源数量排序返回面试题，可使用 `categories` 和 `platform` 查询参数过滤，支持 `page` 和 `pageSize` 分页查询（不传则返回全部）。
+
 ## 部署到 Serverless
 
 项目默认在本地运行，但也可部署到腾讯云函数（SCF）。部署时需保证 `scf_bootstrap` 为可执行文件，并在函数入口设置为该脚本。同时需在环境变量中配置所有外部服务的密钥。

--- a/app.js
+++ b/app.js
@@ -15,6 +15,7 @@ const userRoutes = require('./routes/user');      // 用户数据模块
 const authRoutes = require('./routes/auth');      // 登录模块
 const { router: picRoutes, takeScreenshot } = require('./routes/pic');      // 图片上传模块
 const chatRoutes = require('./routes/chat');      // 聊天模块
+const interviewRoutes = require('./routes/interview');      // 面试题模块
 
 // ---------- 中间件配置 ----------
 // 配置 CORS（根据你的前端地址调整）
@@ -103,6 +104,7 @@ app.use(authMiddleware);
 app.use('/user', userRoutes);
 app.use('/pic', picRoutes);
 app.use('/chat', chatRoutes);
+app.use('/interview', interviewRoutes);
 
 // ---------- 全局错误处理 ----------
 app.use((err, req, res, next) => {

--- a/interview.js
+++ b/interview.js
@@ -1,0 +1,2 @@
+const router = require('./routes/interview');
+module.exports = router;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ai-cv-cf",
+  "name": "ai-cv-cloud-function",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -16,6 +16,7 @@
         "firebase-admin": "^13.4.0",
         "jsonwebtoken": "^9.0.2",
         "multer": "^1.4.5-lts.1",
+        "mysql2": "^3.9.7",
         "node-fetch": "^2.7.0",
         "puppeteer": "^24.4.0",
         "puppeteer-core": "^24.4.0",
@@ -931,6 +932,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/aws-ssl-profiles": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+      "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/aws4": {
@@ -2312,6 +2322,15 @@
         "node": ">=14"
       }
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "http://gz.npm.tencentyun.com/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2904,6 +2923,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -3249,8 +3274,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0",
-      "optional": true
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -3278,6 +3302,21 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lru.min": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.2.tgz",
+      "integrity": "sha512-Nv9KddBcQSlQopmBHXSsZVY5xsdlZkdH/Iey0BlcBYggMd4two7cZnKOK9vmy3nY0O5RGH99z1PCeTpPqszUYg==",
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
       }
     },
     "node_modules/make-dir": {
@@ -3446,6 +3485,68 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/mysql2": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.14.1.tgz",
+      "integrity": "sha512-7ytuPQJjQB8TNAYX/H2yhL+iQOnIBjAMam361R7UAL0lOVXWjtdrmoL9HYKqKoLp/8UUTRcvo1QPvK9KL7wA8w==",
+      "license": "MIT",
+      "dependencies": {
+        "aws-ssl-profiles": "^1.1.1",
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^5.2.1",
+        "lru.min": "^1.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/mysql2/node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/mysql2/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.3.tgz",
+      "integrity": "sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==",
+      "license": "MIT",
+      "dependencies": {
+        "lru-cache": "^7.14.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/named-placeholders/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/negotiator": {
@@ -4346,6 +4447,11 @@
       "resolved": "http://gz.npm.tencentyun.com/npm/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
+    },
     "node_modules/serve-static": {
       "version": "1.16.2",
       "resolved": "http://gz.npm.tencentyun.com/npm/serve-static/-/serve-static-1.16.2.tgz",
@@ -4535,6 +4641,15 @@
       "version": "1.1.3",
       "resolved": "http://gz.npm.tencentyun.com/npm/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/sshpk": {
       "version": "1.18.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "redis": "^3.1.2",
     "resend": "^4.1.2",
     "tencentcloud-sdk-nodejs": "^4.1.26",
-    "firebase-admin": "^13.4.0"
+    "firebase-admin": "^13.4.0",
+    "mysql2": "^3.9.7"
   }
 }

--- a/routes/interview.js
+++ b/routes/interview.js
@@ -1,0 +1,75 @@
+const express = require('express');
+const router = express.Router();
+const pool = require('../utils/mysql');
+
+// 接口0: 获取元信息（平台列表和分类列表）
+router.get('/meta', async (req, res) => {
+  try {
+    const [rows] = await pool.query('SELECT platform, categories FROM interview_question');
+    const platformSet = new Set();
+    const categorySet = new Set();
+
+    rows.forEach(row => {
+      try {
+        JSON.parse(row.platform || '[]').forEach(p => platformSet.add(p));
+        JSON.parse(row.categories || '[]').forEach(c => categorySet.add(c));
+      } catch (e) {
+        // ignore parse errors
+      }
+    });
+
+    res.json({ code: 200, data: { platforms: Array.from(platformSet), categories: Array.from(categorySet) } });
+  } catch (err) {
+    console.error('[interview/meta] error:', err);
+    res.status(500).json({ code: 500, message: 'database error' });
+  }
+});
+
+// 接口1: 获取面试题列表
+router.get('/questions', async (req, res) => {
+  try {
+    const [rows] = await pool.query('SELECT * FROM interview_question');
+    const { categories, platform } = req.query;
+
+    const categoryFilter = categories ? categories.split(',').map(s => s.trim()).filter(Boolean) : null;
+    const platformFilter = platform ? platform.split(',').map(s => s.trim()).filter(Boolean) : null;
+
+    let result = [];
+
+    rows.forEach(row => {
+      try {
+        row.platform = JSON.parse(row.platform || '[]');
+        row.categories = JSON.parse(row.categories || '[]');
+        row.sources = JSON.parse(row.sources || '[]');
+        row.sourcesCount = Array.isArray(row.sources) ? row.sources.length : 0;
+      } catch (e) {
+        row.sourcesCount = 0;
+      }
+
+      if (categoryFilter && !row.categories.some(c => categoryFilter.includes(c))) {
+        return;
+      }
+      if (platformFilter && !row.platform.some(p => platformFilter.includes(p))) {
+        return;
+      }
+      result.push(row);
+    });
+
+    result.sort((a, b) => b.sourcesCount - a.sourcesCount);
+
+    const page = parseInt(req.query.page, 10);
+    const pageSize = parseInt(req.query.pageSize, 10);
+    let pagedResult = result;
+    if (!isNaN(page) && !isNaN(pageSize) && page > 0 && pageSize > 0) {
+      const start = (page - 1) * pageSize;
+      pagedResult = result.slice(start, start + pageSize);
+    }
+
+    res.json({ code: 200, data: pagedResult });
+  } catch (err) {
+    console.error('[interview/questions] error:', err);
+    res.status(500).json({ code: 500, message: 'database error' });
+  }
+});
+
+module.exports = router;

--- a/utils/mysql.js
+++ b/utils/mysql.js
@@ -1,0 +1,13 @@
+const mysql = require('mysql2/promise');
+
+const pool = mysql.createPool({
+  host: process.env.MYSQL_HOST,
+  port: process.env.MYSQL_PORT || 3306,
+  user: process.env.MYSQL_USER,
+  password: process.env.MYSQL_PASSWORD,
+  database: process.env.MYSQL_DATABASE,
+  waitForConnections: true,
+  connectionLimit: 10,
+});
+
+module.exports = pool;


### PR DESCRIPTION
## Summary
- integrate mysql2 driver
- add database settings to `.env.example`
- implement `/interview` routes with metadata and questions endpoints
- expose interview router in `app.js`
- document interview API in README
- support question pagination and rename `interview._qajs` to `interview.js`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bbb3837fc832ba66206479db4bb31