### PR TITLE
Add interview question detail API

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 
 - `GET /interview/meta` 获取所有来源平台及分类列表。
 - `GET /interview/questions` 按来源数量排序返回面试题，可使用 `categories` 和 `platform` 查询参数过滤，支持 `page` 和 `pageSize` 分页查询（不传则返回全部）。
+- `GET /interview/questions/:id` 根据题目 ID 返回该题目的详细信息。
 
 ## 部署到 Serverless
 

--- a/routes/interview.js
+++ b/routes/interview.js
@@ -77,4 +77,27 @@ router.get('/questions', async (req, res) => {
   }
 });
 
+// 接口2: 根据id获取单个面试题详情
+router.get('/questions/:id', async (req, res) => {
+  try {
+    const questionId = req.params.id;
+    const [rows] = await pool.query('SELECT * FROM interview_question WHERE id = ?', [questionId]);
+    if (rows.length === 0) {
+      return res.status(404).json({ code: 404, message: 'question not found' });
+    }
+
+    const question = rows[0];
+    try {
+      question.sources = JSON.parse(question.sources || '[]');
+    } catch (e) {
+      question.sources = [];
+    }
+
+    res.json({ code: 200, data: question });
+  } catch (err) {
+    console.error('[interview/question] error:', err);
+    res.status(500).json({ code: 500, message: 'database error' });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- add endpoint to fetch interview question by ID
- document the new API in README

## Testing
- `node -e "require('./routes/interview')"` *(fails: Cannot find module 'express')*
- `npm install` *(fails due to ECONNRESET: socket hang up)*

------
https://chatgpt.com/codex/tasks/task_e_684bd8906e10832bbdbcb3aa48e09f48